### PR TITLE
bugfix usage of `case_insensitive_keys` parameter

### DIFF
--- a/agenta-backend/agenta_backend/services/evaluators_service.py
+++ b/agenta-backend/agenta_backend/services/evaluators_service.py
@@ -811,6 +811,7 @@ def compare_jsons(
     flattened_app_output = normalize_keys(flattened_app_output, case_insensitive_keys)
 
     for key in keys:
+        key = key.lower() if case_insensitive_keys else key
         ground_truth_value = flattened_ground_truth.get(key, None)
         llm_app_output_value = flattened_app_output.get(key, None)
 


### PR DESCRIPTION
The json keys were stored in the variable `keys` before the method  ".lower()" is applied inside normalize_keys().
As a results the loop `for key in keys` iterates over the original keys, not the lowered() ones.

I'm aware tests folders are being refactored so I'm just dropping here a quick and dirty draft of test cases for future reference.
Once the refactoring is completed I can finalise the PR and convert this test casese to pytest or any other adaptation needed.

```
import unittest
# import the compare_jsons function

class TestCompareJsons(unittest.TestCase):
    
    def test_compare_jsons_identical_input(self):
        ground_truth = {
            "key1": "value1",
            "key2": {
                "nested_key": "nested_value"
            },
            "key3": [1, 2, 3]
        }
        app_output = ground_truth.copy()
        settings_values = {}
    
        result = compare_jsons(ground_truth, app_output, settings_values)
    
        self.assertEqual(result, 1.0)
    
    def test_compare_jsons_completely_different_input(self):
        ground_truth = {
            "key1": "value1",
            "key2": {
                "nested_key": "nested_value"
            },
            "key3": [1, 2, 3]
        }
        app_output = {
            "different_key1": "different_value1",
            "different_key2": {
                "different_nested_key": "different_nested_value"
            },
            "different_key3": [4, 5, 6]
        }
        settings_values = {}
    
        result = compare_jsons(ground_truth, app_output, settings_values)
    
        self.assertEqual(result, 0.0)

    def test_compare_jsons_nested_objects(self):
        ground_truth = {
            "key1": "value1",
            "key2": {
                "nested_key1": "nested_value1",
                "nested_key2": {
                    "deeply_nested_key": "deeply_nested_value"
                }
            },
            "key3": [1, {"list_nested_key": "list_nested_value"}, 3]
        }
        app_output = {
            "key1": "value1",
            "key2": {
                "nested_key1": "nested_value1",
                "nested_key2": {
                    "deeply_nested_key": "deeply_nested_value"
                }
            },
            "key3": [1, {"list_nested_key": "list_nested_value"}, 3]
        }
        settings_values = {}
    
        result = compare_jsons(ground_truth, app_output, settings_values)
    
        self.assertEqual(result, 1.0)
        
    def test_compare_jsons_case_insensitive_keys(self):
        ground_truth = {
            "Key1": "value1",
            "KEY2": {
                "NestedKey": "nested_value"
            },
            "kEy3": "abc"
        }
        app_output = {
            "key1": "value1",
            "key2": {
                "nestedkey": "nested_value"
            },
            "Key3": "abc"
        }
        settings_values = {"case_insensitive_keys": True}
    
        result = compare_jsons(ground_truth, app_output, settings_values)
    
        self.assertEqual(result, 1.0)
        
    def test_compare_jsons_schema_only(self):
        ground_truth = {
            "key1": "value1",
            "key2": {
                "nested_key": "nested_value"
            },
            "key3": [1, 2, 3]
        }
        app_output = {
            "key1": "different_value1",
            "key2": {
                "nested_key": "different_nested_value"
            },
            "key3": [4, 5, 6]
        }
        settings_values = {"compare_schema_only": True}
    
        result = compare_jsons(ground_truth, app_output, settings_values)
    
        self.assertEqual(result, 1.0)

    def test_compare_jsons_predict_keys(self):
        ground_truth = {
            "key1": "value1",
            "key2": "value2"
        }
        app_output = {
            "key2": "value2",
            "key3": "value3"
        }
        settings_values = {"predict_keys": True}
    
        result = compare_jsons(ground_truth, app_output, settings_values)
    
        self.assertAlmostEqual(result, 1/3, places=2)

    def test_compare_jsons_empty_input(self):
        ground_truth = {}
        app_output = {}
        settings_values = {}
    
        result = compare_jsons(ground_truth, app_output, settings_values)
    
        self.assertEqual(result, 0.0)
    
    def test_compare_jsons_with_nested_lists(self):
        ground_truth = {
            "key1": "value1",
            "key2": [1, 2, {"nested_key": [3, 4, 5]}],
            "key3": {"a": [6, 7], "b": [8, 9]}
        }
        app_output = {
            "key1": "value1",
            "key2": [1, 2, {"nested_key": [3, 4, 5]}],
            "key3": {"a": [6, 7], "b": [8, 9]}
        }
        settings_values = {}
    
        result = compare_jsons(ground_truth, app_output, settings_values)
    
        self.assertEqual(result, 1.0)
        
    def test_compare_jsons_partial_match(self):
        ground_truth = {
            "key1": "value1",
            "key2": {
                "nested_key": "nested_value"
            },
            "key3": [1, 2, 3]
        }
        app_output = {
            "key1": "value1",
            "key2": {
                "nested_key": "different_value"
            },
            "key3": [1, 2, 3],
            "key4": "extra_value"
        }
        settings_values = {"predict_keys": True}

        result = compare_jsons(ground_truth, app_output, settings_values)

        self.assertAlmostEqual(result, 2.0 / 3, places=2)
```